### PR TITLE
Fix chrome bug with bullets on far left

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -21,3 +21,7 @@ h1 {
 h2 {
     color: #FF8F35;
 }
+
+ul, ol {
+    list-style-position:inside;
+}

--- a/templates/completed_tasks.php
+++ b/templates/completed_tasks.php
@@ -3,31 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <title>To Do App - Completed Items</title>
-    <style>
-        body {
-            margin: 50px 0 0 0;
-            padding: 0;
-            width: 100%;
-            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-            text-align: center;
-            color: #000;
-            font-size: 18px;
-            background-color: #FCFFCD;
-        }
-
-        h1 {
-            color: #FF8F35;
-            letter-spacing: -3px;
-            font-family: 'Lato', sans-serif;
-            font-size: 100px;
-            font-weight: 200;
-            margin-bottom: 0;
-        }
-        h2 {
-            color: #FF8F35;
-        }
-    </style>
+    <link href="style.css" type="text/css" rel="stylesheet">
 </head>
+
 <body>
 <h1>To Do List</h1>
 


### PR DESCRIPTION
Fix chrome bug with bullets for a centered list show on the far left of the browser, but look fine in Firefox

Updated style.css to include 'list-style-position:inside;' so that lists in chrome show bullets near to list items, and updated completed_tasks.php to refer to that css